### PR TITLE
feat: 매칭 프로필 상세보기 API 구현

### DIFF
--- a/Eiii/accounts/serializers.py
+++ b/Eiii/accounts/serializers.py
@@ -35,15 +35,23 @@ class SignUpSerializer(serializers.ModelSerializer):
         user.save()
         return user
     
-#프로필   
+#매칭 프로필 상세보기용
 class ProfileSerializer(serializers.ModelSerializer):
     preferred_menu = serializers.ListField(child=serializers.CharField())
     dietary_restrictions = serializers.ListField(child=serializers.CharField())
-    
+    username = serializers.SerializerMethodField()
+    nickname = serializers.SerializerMethodField()
+
     class Meta:
         model = Profile
         fields = '__all__'
+        #exclude = ['user'] 해당 프로필을 소유한 사용자 ID 숨기려면 
         read_only_fields = ['user']    
+    
+    def get_nickname(self, obj):
+        return getattr(obj.user, 'nickname', None)
+    def get_username(self, obj):
+        return obj.user.username
 
 #매칭 프로필 미리보기용
 class ProfilePreviewSerializer(serializers.ModelSerializer):
@@ -63,6 +71,6 @@ class ProfilePreviewSerializer(serializers.ModelSerializer):
         ]
 
     def get_nickname(self, obj):
-        return obj.user.nickname  
+        return getattr(obj.user, 'nickname', None)
     def get_username(self, obj):
         return obj.user.username

--- a/Eiii/accounts/urls.py
+++ b/Eiii/accounts/urls.py
@@ -1,7 +1,7 @@
 from django.urls import path
 from .views import SignUpView, ProfileCreateView
 from rest_framework_simplejwt.views import TokenObtainPairView, TokenRefreshView
-from .views import LogoutView, MatchView
+from .views import LogoutView, MatchView, ProfileDetailView
 
 urlpatterns = [
     path('signup/', SignUpView.as_view(), name='signup'),
@@ -10,4 +10,5 @@ urlpatterns = [
     path('profile/', ProfileCreateView.as_view(), name='profile-create'),
     path('logout/', LogoutView.as_view(), name='logout'),
     path('match/', MatchView.as_view(), name='match'),
+    path('profile/<int:pk>/', ProfileDetailView.as_view(), name='profile-detail'),
 ]

--- a/Eiii/accounts/views.py
+++ b/Eiii/accounts/views.py
@@ -8,6 +8,7 @@ from .models import Profile
 from .serializers import ProfileSerializer
 from rest_framework_simplejwt.tokens import RefreshToken
 from .serializers import ProfilePreviewSerializer
+from rest_framework.generics import RetrieveAPIView
 
 
 class SignUpView(APIView):
@@ -81,3 +82,8 @@ class MatchView(APIView):
         top_matches = sorted_profiles[:6]
         serializer = ProfilePreviewSerializer(top_matches, many=True)
         return Response(serializer.data)
+
+class ProfileDetailView(RetrieveAPIView):
+    queryset = Profile.objects.all()
+    serializer_class = ProfileSerializer
+    permission_classes = [IsAuthenticated]


### PR DESCRIPTION
related to #6

## 📌 작업 내용
- 매칭 미리보기에서 선택하면 매칭 프로필 정보를 다 볼 수 있는 API 구현

## 🔍 작업 상세
- [x] 매칭 프로필 상세보기 API 구현

## 🧪 테스트 결과
- [x] Postman 테스트 완료
<img width="440" alt="image" src="https://github.com/user-attachments/assets/693f41bf-9bda-4717-b7cb-406227db2e42" />

## 🗨 기타 참고 사항
- 이슈 번호: `#1`
