### PR TITLE
feat: 프로필 조회, 수정, 미리보기 조회 API 추가

### DIFF
--- a/Eiii/accounts/urls.py
+++ b/Eiii/accounts/urls.py
@@ -1,14 +1,17 @@
 from django.urls import path
 from .views import SignUpView, ProfileCreateView
 from rest_framework_simplejwt.views import TokenObtainPairView, TokenRefreshView
-from .views import LogoutView, MatchView, ProfileDetailView
+from .views import LogoutView, MatchView, ProfileDetailView, MyProfileView, MyProfilePreviewView, ProfilePreviewView 
 
 urlpatterns = [
     path('signup/', SignUpView.as_view(), name='signup'),
     path('login/', TokenObtainPairView.as_view(), name='token_obtain_pair'),
     path('token/refresh/', TokenRefreshView.as_view(), name='token_refresh'),
-    path('profile/', ProfileCreateView.as_view(), name='profile-create'),
+    path('profile/create/', ProfileCreateView.as_view(), name='profile-create'),
+    path('profile/me/', MyProfileView.as_view(), name='my-profile'),
+    path('profile/me/preview/', MyProfilePreviewView.as_view(), name='my-profile-preview'),
     path('logout/', LogoutView.as_view(), name='logout'),
     path('match/', MatchView.as_view(), name='match'),
-    path('profile/<int:pk>/', ProfileDetailView.as_view(), name='profile-detail'),
+    path('profile/<int:pk>/preview/', ProfilePreviewView.as_view(), name='profile-preview'),  # 다른 사람 미리보기
+    path('profile/<int:pk>/', ProfileDetailView.as_view(), name='profile-detail'),            # 다른 사람 상세
 ]

--- a/Eiii/accounts/views.py
+++ b/Eiii/accounts/views.py
@@ -5,10 +5,10 @@ from .serializers import SignUpSerializer
 from rest_framework.permissions import IsAuthenticated
 from rest_framework import generics
 from .models import Profile
-from .serializers import ProfileSerializer
+from .serializers import ProfileSerializer, ProfilePreviewSerializer
 from rest_framework_simplejwt.tokens import RefreshToken
 from .serializers import ProfilePreviewSerializer
-from rest_framework.generics import RetrieveAPIView
+from rest_framework.generics import RetrieveAPIView, RetrieveUpdateAPIView
 
 
 class SignUpView(APIView):
@@ -26,6 +26,25 @@ class ProfileCreateView(generics.CreateAPIView):
 
     def perform_create(self, serializer):
         serializer.save(user=self.request.user)
+
+class MyProfileView(RetrieveUpdateAPIView):
+    serializer_class = ProfileSerializer
+    permission_classes = [IsAuthenticated]
+
+    def get_object(self):
+        return Profile.objects.get(user=self.request.user)
+    
+class MyProfilePreviewView(RetrieveAPIView):
+    serializer_class = ProfilePreviewSerializer
+    permission_classes = [IsAuthenticated]
+
+    def get_object(self):
+        return Profile.objects.get(user=self.request.user)
+
+class ProfilePreviewView(RetrieveAPIView):
+    queryset = Profile.objects.all()
+    serializer_class = ProfilePreviewSerializer
+    permission_classes = [IsAuthenticated]
 
 class LogoutView(APIView):
     permission_classes = [IsAuthenticated]


### PR DESCRIPTION
related to #10

## 📌 작업 내용
- 마이페이지에서 내 프로필 조회, 수정, 미리보기 API 구현
- 매칭 프로필 url 수정

## 🔍 작업 상세
- [ ] 내 프로필 정보 조회 API 구현
- [ ] 내 프로필 정보 수정 API 구현 
- [ ] 내 프로필 정보 미리보기 API 구현
- [ ] 매칭 프로필 url 수정

## 🧪 테스트 결과
- [ ] Postman 테스트 완료
- 내 프로필 정보 조회 API 구현
<img width="454" alt="Image" src="https://github.com/user-attachments/assets/24e93399-06f0-47e4-b40d-a551b26387db" />
- 내 프로필 정보 수정 API
<img width="497" alt="Image" src="https://github.com/user-attachments/assets/fa15928c-444c-477d-ae8c-8dad10a30ed6" />
- 내 프로필 정보 미리보기
<img width="454" alt="Image" src="https://github.com/user-attachments/assets/df2acb64-a43d-45e1-a8e0-750aeecded17" />
- 매칭 프로필 미리보기
<img width="459" alt="Image" src="https://github.com/user-attachments/assets/63c33550-0493-4daa-ba76-8c06b4ba19b8" />
- 매칭 프로필 상세보기
<img width="452" alt="Image" src="https://github.com/user-attachments/assets/d82fe712-9f62-48da-bee2-45efa5d5a1d4" />

## 🗨 기타 참고 사항
- 이슈 번호: `#10`
- 논의가 필요한 부분이 있다면 여기에 작성해주세요.
